### PR TITLE
✨ Added title type for job adverts

### DIFF
--- a/schemas/JobAdvert.js
+++ b/schemas/JobAdvert.js
@@ -17,6 +17,13 @@ export default {
             type: 'string',
         },
         {
+            name: 'title',
+            title: 'Tittel',
+            description: 'Tittel på stillingsannonse, f.eks: "Bekk søker nyutdannede utviklere til bla bla bla"',
+            validation: (Rule) => Rule.required(),
+            type: 'string',
+        },
+        {
             name: 'slug',
             title: 'Slug (link)',
             validation: (Rule) => Rule.required(),


### PR DESCRIPTION
Job adverts usually have a title eg. "Bedrift søker nyutdannede systemutviklere" etc.

**Note:** Draft PR - in case of adding/changing features
