### PR TITLE
:sparkles: Url to location

### DIFF
--- a/schemas/Happening.js
+++ b/schemas/Happening.js
@@ -69,6 +69,11 @@ export default {
             type: 'string',
         },
         {
+            name: 'locationLink',
+            title: 'Url til sted (Google Maps eller MazeMap)',
+            type: 'url',
+        },
+        {
             name: 'author',
             title: 'Forfatter',
             validation: (Rule) => Rule.required(),


### PR DESCRIPTION
Nytt felt som tar inn en URL, helst fra enten Google Maps eller MazeMap. Typen URL har default validation på http og https.