### PR TITLE
En jobb kan ha flere steder, og nå er det forskjell på internship eller sommerjobb

### DIFF
--- a/schemas/JobAdvert.js
+++ b/schemas/JobAdvert.js
@@ -53,7 +53,7 @@ export default {
         {
             name: 'locations',
             title: 'Sted(er)',
-            validation: (Rule) => Rule.required(),
+            validation: (Rule) => Rule.required().unique(),
             type: 'array',
             of: [{ type: 'string' }],
         },
@@ -81,7 +81,7 @@ export default {
         {
             name: 'degreeYears',
             title: 'Aktuelle årstrinn',
-            validation: (Rule) => Rule.required(),
+            validation: (Rule) => Rule.required().unique(),
             type: 'array',
             of: [{ type: 'number' }],
         },

--- a/schemas/JobAdvert.js
+++ b/schemas/JobAdvert.js
@@ -54,7 +54,8 @@ export default {
             name: 'location',
             title: 'Sted',
             validation: (Rule) => Rule.required(),
-            type: 'string',
+            type: 'array',
+            of: [{ type: 'string' }],
         },
         {
             name: 'jobType',

--- a/schemas/JobAdvert.js
+++ b/schemas/JobAdvert.js
@@ -66,7 +66,8 @@ export default {
                 list: [
                     { title: 'Fulltid', value: 'fulltime' },
                     { title: 'Deltid', value: 'parttime' },
-                    { title: 'Sommerjobb', value: 'internship' },
+                    { title: 'Internship', value: 'internship' },
+                    { title: 'Sommerjobb', value: 'summerjob' },
                 ],
                 layout: 'dropdown',
             },

--- a/schemas/JobAdvert.js
+++ b/schemas/JobAdvert.js
@@ -51,8 +51,8 @@ export default {
             type: 'datetime',
         },
         {
-            name: 'location',
-            title: 'Sted',
+            name: 'locations',
+            title: 'Sted(er)',
             validation: (Rule) => Rule.required(),
             type: 'array',
             of: [{ type: 'string' }],


### PR DESCRIPTION
Location er nå en array, så du kan legge til så mange steder du vil. Tenker å kjøre `map`-funksjonen på alle stedene location blir brukt i frontend. Da går den bare over alle stedene. Vet ikke hvordan dette "sorter etter sted".

Har også lagt til sommerjobb og endret på internship i `jobType`. Internship holder verdien `internship`, mens sommerjobb har verdien `summerjob`. 